### PR TITLE
Company's names containing comma(s)

### DIFF
--- a/lib/DB/BDD.cpp
+++ b/lib/DB/BDD.cpp
@@ -41,8 +41,15 @@ vector<Company*> getCompanies()
         while (getline(s, data, ',')) {
             dataLine.push_back(data) ;
         }
+
+        // Concatenate the fields corresponding to company's name (which were separated with a comma) => Ex: Google, Inc.
+        for (unsigned int i = 2; i < dataLine.size() - 2; i++) {
+            dataLine[1] = dataLine[1] + "," + dataLine[i] ;
+        }
+
+        Company *company = new Company(dataLine[1], dataLine[dataLine.size() - 2], dataLine[dataLine.size() - 1]) ;
+
         companyId = stoi(dataLine[0]) ;
-        Company *company = new Company(dataLine[1], dataLine[2], dataLine[3]) ;
         company->setId(companyId) ;
 
         companies.push_back(company) ;

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -111,6 +111,17 @@ int main()
         TEST (companies[0]->getId() == 1) ;
         TEST (!companies[1]->getName().compare("Google")) ;
         TEST (!companies[2]->getZipcode().compare("31")) ;
+
+        // Tests comapany names with comma(s) (other functions are already tested below)
+        Company* googleInc = new Company("Google, Inc.", "09700", "contact@google.fr") ;
+        googleInc->createProfile(companies) ;
+
+        
+        updateEntry(companies) ;
+        companies = getCompanies() ;
+
+        int googleIncIndex = Company::getIndex(googleInc->getId(), companies) ;
+        TEST(!companies[googleIncIndex]->getName().compare("Google, Inc.")) ;
     }
 
     // getCompany


### PR DESCRIPTION
I made changes in the getCompanies function of BDD in order to make it work with company names containing comma(s).

Before these changes, because of the comma, the name was separated into different fields because of the CSV format. SO the second part of the company name was overriding the zipcode for example.