### PR TITLE
Bug deleted colleagues

### DIFF
--- a/lib/DB/BDD.cpp
+++ b/lib/DB/BDD.cpp
@@ -247,8 +247,7 @@ vector<Employee*> getEmployees()
     for (unsigned int i = 0; i < employees.size(); i++) {
         for (unsigned int j = 0; j < employees[i]->getColleagues().size(); j++) {
             if (!employees[i]->getColleagues()[j]->getName().compare("undefined")) {
-                Employee *e = new Employee(*employees[employees[i]->getColleagues()[j]->getId() - 1]) ;
-                employees[i]->getColleagues()[j] = e ;
+                employees[i]->getColleagues()[j] = employees[Employee::getIndex(employees[i]->getColleagues()[j]->getId(), employees)] ;
             }
         }
     }

--- a/lib/People/Employee.cpp
+++ b/lib/People/Employee.cpp
@@ -128,17 +128,26 @@ int Employee::addColleague(Employee &e)
     return 0 ;
 }
 
-void Employee::deleteProfile(vector<Employee*> &list)
+void Employee::deleteProfile(vector<Employee*> &list, vector<JobSeeker*> &jobSeekers)
 {
     vector<Employee*>::iterator it ;
     int colleagueIndex ;
 
-    // Remove employee from colleagues of other employees
+    // Removes employee from colleagues of other employees
     for (auto e : list) {
         colleagueIndex = Employee::getIndex(_id, e->getColleagues()) ;
         if (colleagueIndex != -1) {
             it = e->getColleagues().begin() + colleagueIndex ;
             e->getColleagues().erase(it) ;
+        }
+    }
+
+    // Removes employee from colleagues of job seekers
+    for (auto js : jobSeekers) {
+        colleagueIndex = Employee::getIndex(_id, js->getColleagues()) ;
+        if (colleagueIndex != -1) {
+            it = js->getColleagues().begin() + colleagueIndex ;
+            js->getColleagues().erase(it) ;
         }
     }
 
@@ -153,7 +162,7 @@ JobSeeker* Employee::employeeToJobSeeker(vector<Employee*> &employees, vector<Jo
     JobSeeker* js = new JobSeeker (_name, _firstname, _email, _zipcode, _skills, _oldColleagues) ;
     js->createProfile(jobseekers) ;
 
-    this->deleteProfile(employees) ;
+    this->deleteProfile(employees, jobseekers) ;
 
     // We add the employees of the company left in the colleagues
     for (auto e : employees) {

--- a/lib/People/Employee.cpp
+++ b/lib/People/Employee.cpp
@@ -130,7 +130,20 @@ int Employee::addColleague(Employee &e)
 
 void Employee::deleteProfile(vector<Employee*> &list)
 {
-    auto it = list.begin() + Employee::getIndex(_id, list) ;
+    vector<Employee*>::iterator it ;
+    int colleagueIndex ;
+
+    // Remove employee from colleagues of other employees
+    for (auto e : list) {
+        colleagueIndex = Employee::getIndex(_id, e->getColleagues()) ;
+        if (colleagueIndex != -1) {
+            it = e->getColleagues().begin() + colleagueIndex ;
+            e->getColleagues().erase(it) ;
+        }
+    }
+
+    // Remove from global vector
+    it = list.begin() + Employee::getIndex(_id, list) ;
     delete * it ;
     list.erase(it) ;
 }

--- a/lib/People/Employee.h
+++ b/lib/People/Employee.h
@@ -54,8 +54,9 @@ class Employee
     // Returns 1 otherwise
     int addColleague (Employee &e) ;
 
-    // Deletes Employee profile from the list and DB
-    void deleteProfile(std::vector<Employee*> &list) ;
+    // Deletes Employee profile from the global vector
+    // Also removes its reference from the employees or job seekers he was colleague with
+    void deleteProfile(std::vector<Employee*> &list, std::vector<JobSeeker*> &jobSeekers) ;
 
     // Transitions an Employee to a JobSeeker
     // Deletes profile from Employee list and adds it to JobSeekers list

--- a/lib/UI/CLI/cli.cpp
+++ b/lib/UI/CLI/cli.cpp
@@ -714,7 +714,7 @@ void Cli::printMenuEmployee(int id)
 					logger(_logpath, "Employee.deleteProfile", args);
 				}
 
-				_employees[Employee::getIndex(id, _employees)]->deleteProfile(_employees);
+				_employees[Employee::getIndex(id, _employees)]->deleteProfile(_employees, _jobSeekers);
 				system("clear");
 				cout << BOLD(FRED("Succesfuly deleted your profile")) << endl;
 				wait();

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -301,7 +301,7 @@ int main()
 
         // deleteProfile
         unsigned int sizeEmployees = employees.size() ;
-        e->deleteProfile(employees) ;
+        e->deleteProfile(employees, jobSeekers) ;
         TEST (employees.size() == sizeEmployees - 1) ;
 
         // employeeToJobSeeker


### PR DESCRIPTION
Now, when a an employee deletes its profile (manually or by transitioning to a job seeker profile), the references to it in the colleagues vector of other employees or job seekers are removed. 
