### PR TITLE
Install libsqlite3-dev in CI script

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -4,12 +4,15 @@ on:
   pull_request:
     branches:
     - master
+    - csv_to_sql
 
 jobs:
   build-and-test-linux:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: sudo apt-get install -y -qq libsqlite3-dev
     - name: Build all
       run: make all
     - name: Test


### PR DESCRIPTION
### Modification(s) apportée(s)

- Insère une nouvelle étape dans le script d'intégration continu pour installer des bibliothèques tierce-partie.
- Installe la bibliothèque `libsqlite3-dev` nécéssaire à la conversion de la base de données.

### Problème(s) résolu(s)

Cette bibliothèque n'est pas disponible par défault sur l'image `ubuntu-latest` et le build automatique s'arrête à une erreur de compilation parce que l'en-tête `sqlite3.h` manque.

### Vérification(s) et test(s)

Si le PR passe, c'est que le problème est résolu.